### PR TITLE
(feat): host

### DIFF
--- a/beacon-chain/p2p/libp2p/host/host.go
+++ b/beacon-chain/p2p/libp2p/host/host.go
@@ -1,0 +1,115 @@
+package host
+
+import (
+	"context"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/config"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/network"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/peer"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/peerstore"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/protocol"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/transport"
+
+	ma "github.com/multiformats/go-multiaddr"
+	mss "github.com/multiformats/go-multistream"
+)
+
+type Host interface {
+	// ID returns the (local) peer.ID associated with this Host
+	ID() peer.ID
+	// Peerstore returns the Host's repository of Peer Addresses and Keys.
+	Peerstore() *peerstore.PeerStore
+
+	// Returns the listen addresses of the Host
+	Addrs() []ma.Multiaddr
+
+	// Networks returns the Network interface of the Host
+	Network() network.Network
+
+	// Mux returns the Mux multiplexing incoming streams to protocol handlers
+	Mux() *mss.MultistreamMuxer[protocol.ID]
+
+	// Connect ensures there is a connection between this host and the peer with
+	// given peer.ID. Connect will absorb the addresses in pi into its internal
+	// peerstore. If there is not an active connection, Connect will issue a
+	// h.Network.Dial, and block until a connection is open, or an error is
+	// returned. // TODO: Relay + NAT.
+	Connect(ctx context.Context, pi peer.AddrInfo) error
+
+	// SetStreamHandler sets the protocol handler on the Host's Mux.
+	// This is equivalent to:
+	//   host.Mux().SetHandler(proto, handler)
+	// (Thread-safe)
+	SetStreamHandler(pid protocol.ID, handler transport.StreamHandler)
+
+	// RemoveStreamHandler removes a handler on the mux that was set by
+	// SetStreamHandler
+	RemoveStreamHandler(pid protocol.ID)
+
+	// NewStream opens a new stream to given peer p, and writes a p2p/protocol
+	// header with given ProtocolID. If there is no connection to p, attempts
+	// to create one. If ProtocolID is "", writes no header.
+	// (Thread-safe)
+	NewStream(ctx context.Context, pid peer.ID, protos ...protocol.ID) (transport.Stream, error)
+
+	// Close shuts down the host, its Network, and services.
+	Close() error
+}
+
+type host struct {
+	network network.Network
+}
+
+var _ Host = (*host)(nil)
+
+func NewHost(cfg *config.Config) (*host, error) {
+	n, err := network.NewNetwork(cfg)
+	if err != nil {
+		return nil, err
+	}
+	h := &host{
+		network: n,
+	}
+	return h, nil
+}
+
+func (h *host) ID() peer.ID {
+	return h.network.LocalPeer()
+}
+
+func (h *host) Peerstore() *peerstore.PeerStore {
+	return h.network.Peerstore()
+}
+
+func (h *host) Addrs() []ma.Multiaddr {
+	return h.network.Addrs()
+}
+
+func (h *host) Network() network.Network {
+	return h.network
+}
+
+func (h *host) Mux() *mss.MultistreamMuxer[protocol.ID] {
+	return h.network.Mux()
+}
+
+func (h *host) Connect(ctx context.Context, pinfo peer.AddrInfo) error {
+	return h.network.Connect(ctx, pinfo)
+}
+
+func (h *host) SetStreamHandler(pid protocol.ID, handler transport.StreamHandler) {
+	h.network.SetStreamHandler(pid, handler)
+}
+
+func (h *host) RemoveStreamHandler(pid protocol.ID) {
+	h.network.RemoveStreamHandler(pid)
+}
+
+func (h *host) NewStream(ctx context.Context, pid peer.ID, protos ...protocol.ID) (transport.Stream, error) {
+	return h.network.NewStream(ctx, pid, protos...)
+}
+
+func (h *host) Close() error {
+	h.network.Close()
+	return nil
+}

--- a/beacon-chain/p2p/libp2p/host/host_test.go
+++ b/beacon-chain/p2p/libp2p/host/host_test.go
@@ -1,0 +1,26 @@
+package host_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/peer"
+	test "github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/testing"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+// TODO(max): Most of the logic has been already tested in network_test
+// Host acts like a proxy to Network, a good way of testing would be to have
+// a network mock and test that Host calls the mock's methods.
+func TestHostSimple(t *testing.T) {
+	h1 := test.CreateHost(t)
+	h2 := test.CreateHost(t)
+
+	h2pinfo := &peer.AddrInfo{
+		ID:    h2.Network().LocalPeer(),
+		Addrs: h2.Network().Addrs(),
+	}
+
+	err := h1.Connect(context.Background(), *h2pinfo)
+	require.NoError(t, err)
+}

--- a/beacon-chain/p2p/libp2p/muxer/yamux/yamux.go
+++ b/beacon-chain/p2p/libp2p/muxer/yamux/yamux.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
-// var DefaultTransport *Transport
+var DefaultTransport *Transport
 
 const ID = "/yamux/1.0.0"
 

--- a/beacon-chain/p2p/libp2p/peer/peer.go
+++ b/beacon-chain/p2p/libp2p/peer/peer.go
@@ -1,10 +1,18 @@
 package peer
 
 import (
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/crypto"
+
+	b58 "github.com/mr-tron/base58/base58"
 	ma "github.com/multiformats/go-multiaddr"
+	mh "github.com/multiformats/go-multihash"
 )
 
 type ID string
+
+func (id ID) String() string {
+	return b58.Encode([]byte(id))
+}
 
 // AddrInfo is a small struct used to pass around a peer with
 // a set of addresses.
@@ -28,4 +36,14 @@ func SplitAddr(m ma.Multiaddr) (transport ma.Multiaddr, id ID) {
 	}
 	id = ID(p2ppart.RawValue()) // already validated by the multiaddr library.
 	return transport, id
+}
+
+// IDFromPublicKey returns the Peer ID corresponding to the public key pk.
+func IDFromPublicKey(pk crypto.PubKey) (ID, error) {
+	b, err := crypto.MarshalPublicKey(pk)
+	if err != nil {
+		return "", err
+	}
+	hash, _ := mh.Sum(b, mh.IDENTITY, -1)
+	return ID(hash), nil
 }

--- a/beacon-chain/p2p/libp2p/peer/peer_test.go
+++ b/beacon-chain/p2p/libp2p/peer/peer_test.go
@@ -1,0 +1,68 @@
+package peer
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/crypto"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+// TODO: use ConvertToInterfacePubkey located in crypto/ecdsa/utils.go when
+// legacy libp2p has been replaced by this implementation
+func ConvertToInterfacePubkey(pubkey *ecdsa.PublicKey) (crypto.PubKey, error) {
+	xVal, yVal := new(btcec.FieldVal), new(btcec.FieldVal)
+	if xVal.SetByteSlice(pubkey.X.Bytes()) {
+		return nil, errors.Errorf("X value overflows")
+	}
+	if yVal.SetByteSlice(pubkey.Y.Bytes()) {
+		return nil, errors.Errorf("Y value overflows")
+	}
+	newKey := crypto.PubKey((*crypto.Secp256k1PublicKey)(btcec.NewPublicKey(xVal, yVal)))
+	// Zero out temporary values.
+	xVal.Zero()
+	yVal.Zero()
+	return newKey, nil
+}
+
+func TestIDFromPublicKey(t *testing.T) {
+	type testcase struct {
+		name     string
+		enodeUrl string
+		peerID   string
+	}
+
+	testcases := []testcase{
+		{
+			name:     "Test Vector 1",
+			enodeUrl: "enr:-MS4QA0FMDaj_hAVQgYGzpT698vUUu0sGRMgpWjziNEne44ONahIZTttUIdFS_aF3Z3qOt1baWh54Q6vCXfativyNggBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpBPtyXhYAAAOADh9QUAAAAAgmlkgnY0gmlwhKwQDAuEcXVpY4IjKYlzZWNwMjU2azGhA2CR9Vc5wWxvkpaBkNIFVxdl1apg4Pb70_hSIvslT7YliHN5bmNuZXRzAIN0Y3CCIyiDdWRwgiMo",
+			peerID:   "16Uiu2HAmK9xaMgEbk6xMyWzdiu348n9as6jpwDSZsx3BYtk4c6je",
+		},
+		{
+			name:     "Test Vector 2",
+			enodeUrl: "enr:-Ku4QJsxkOibTc9FXfBWYmcdMAGwH4bnOOFb4BlTHfMdx_f0WN-u4IUqZcQVP9iuEyoxipFs7-Qd_rH_0HfyOQitc7IBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhLAJM9iJc2VjcDI1NmsxoQL2RyM26TKZzqnUsyycHQB4jnyg6Wi79rwLXtaZXty06YN1ZHCCW8w",
+			peerID:   "16Uiu2HAmC13Brucnz5qR8caKi8qKK6766PFoxsF5MzK2RvbTyBRr",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := enode.MustParse(tc.enodeUrl)
+			pubkey := node.Pubkey()
+
+			assertedKey, err := ConvertToInterfacePubkey(pubkey)
+			require.NoError(t, err)
+			id, err := IDFromPublicKey(assertedKey)
+			require.NoError(t, err)
+
+			m, err := mh.FromB58String(tc.peerID)
+			require.NoError(t, err)
+
+			require.Equal(t, ID(m), id)
+		})
+	}
+}

--- a/beacon-chain/p2p/libp2p/testing/utils.go
+++ b/beacon-chain/p2p/libp2p/testing/utils.go
@@ -1,0 +1,32 @@
+package testing_test
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/crypto"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/host"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func CreateHost(t *testing.T) host.Host {
+	t.Helper()
+	h, err := libp2p.New(createOptions(t)...)
+	require.NoError(t, err)
+	return h
+}
+
+func createOptions(t *testing.T) []libp2p.Option {
+	privk, _, err := crypto.GenerateSecp256k1Key()
+	require.NoError(t, err)
+
+	addr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	require.NoError(t, err)
+
+	return []libp2p.Option{
+		libp2p.Identity(privk),
+		libp2p.ListenAddrs(addr),
+	}
+}

--- a/beacon-chain/p2p/libp2p/transport/transport.go
+++ b/beacon-chain/p2p/libp2p/transport/transport.go
@@ -3,9 +3,8 @@ package transport
 import (
 	"context"
 
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/peer"
-
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/libp2p/peer"
 )
 
 // The Transport interface allows you to open connections to other peers


### PR DESCRIPTION
Add Host abstraction. It acts as a proxy to Network for libp2p compatibility. In the long run we might want to remove it and use network directly.